### PR TITLE
Corrects B2 application key secret

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -126,5 +126,5 @@ networks:
 secrets:
   b2_key_id:
     file: ./secrets/b2_key_id
-  b2_application_id:
-    file: ./secrets/b2_application_id
+  b2_application_key:
+    file: ./secrets/b2_application_key


### PR DESCRIPTION
Aligns the Docker Compose secret definition for Backblaze B2 authentication with the correct API key terminology.